### PR TITLE
update refs for recently published RFCs

### DIFF
--- a/attacks-and-mitigations.md
+++ b/attacks-and-mitigations.md
@@ -1254,7 +1254,7 @@ ids, and authenticated TLS client certificates. This data is usually
 passed in HTTP headers added to the upstream request. While the headers
 are often custom, application-specific headers, standardized header
 fields for client certificates and client certificate chains are defined
-in [@I-D.ietf-httpbis-client-cert-field].
+in [@RFC9440].
 
 If the reverse proxy would pass through any header sent from the
 outside, an attacker could try to directly send the faked header

--- a/attacks-and-mitigations.md
+++ b/attacks-and-mitigations.md
@@ -952,8 +952,8 @@ been defined by the OAuth working group:
     tokens. The resource server in the same way obtains the public key
     from the TLS stack and compares its fingerprint with the
     fingerprint associated with the access token.
-  * **DPoP** ([@I-D.ietf-oauth-dpop]): DPoP (Demonstration of
-    Proof-of-Possession at the Application Layer) outlines an
+  * **OAuth 2.0 Demonstrating Proof of Possession (DPoP)** ([@RFC9449]):
+    DPoP outlines an
     application-level sender-constraining for access and refresh
     tokens that can be used in cases where neither mTLS nor OAuth
     Token Binding (see below) are available. It uses
@@ -1339,7 +1339,7 @@ detect refresh token replay by malicious actors for public clients:
 
   * **Sender-constrained refresh tokens:** the authorization server
     cryptographically binds the refresh token to a certain client
-    instance, e.g., by utilizing [@!RFC8705] or [@I-D.ietf-oauth-dpop].
+    instance, e.g., by utilizing [@!RFC8705] or [@RFC9449].
   * **Refresh token rotation:** the authorization server issues a new
     refresh token with every access token refresh response. The
     previous refresh token is invalidated but information about the

--- a/recommendations.md
+++ b/recommendations.md
@@ -136,8 +136,8 @@ of a certain secret as prerequisite for the acceptance of that token at
 the recipient (e.g., a resource server).
 
 Authorization and resource servers SHOULD use mechanisms for sender-constraining
-access tokens, such as Mutual TLS for OAuth 2.0 [@!RFC8705] or OAuth
-Demonstration of Proof of Possession (DPoP) [@I-D.ietf-oauth-dpop] (see
+access tokens, such as Mutual TLS for OAuth 2.0 [@!RFC8705] or OAuth 2.0
+Demonstrating Proof of Possession (DPoP) [@RFC9449] (see
 (#pop_tokens)), to prevent misuse of stolen and leaked access tokens.
 
 ### Refresh Tokens


### PR DESCRIPTION
DPoP is now RFC9449 and ietf-httpbis-client-cert-field is now RFC9440